### PR TITLE
Fix warnings in several LISP routines

### DIFF
--- a/AUTOCAD/LEGACY/LISP/Area Calc Simple.lsp
+++ b/AUTOCAD/LEGACY/LISP/Area Calc Simple.lsp
@@ -3,9 +3,11 @@
 ;; No fancy predicates, works on any AutoCAD 2000-present
 ;; ======================================================================
 
+(defun sqm->ha (a) (/ a 10000.0))
+(defun sqm->ac (a) (/ a 4046.8564224))
+(defun round-str (v d) (rtos v 2 d))
+
 (defun c:AREACALC ( /
-        ;; helper fns
-        sqm->ha sqm->ac round-str
         ;; selections
         ssBoundary ssDispo ssCut ssWet
         ;; objects
@@ -24,9 +26,6 @@
   ;; basic helpers
   ;; ---------------------------------------------------------------
   (vl-load-com)
-  (defun sqm->ha (a) (/ a 10000.0))
-  (defun sqm->ac (a) (/ a 4046.8564224))
-  (defun round-str (v d) (rtos v 2 d))
 
   (prompt "\n=== Area Calculation Started ===")
 

--- a/AUTOCAD/LEGACY/LISP/BendTable with bubbles.lsp
+++ b/AUTOCAD/LEGACY/LISP/BendTable with bubbles.lsp
@@ -1,7 +1,7 @@
 (defun C:BT (/ plObj plPoints i ang nextAng prevAng lastPt thisPt nextPt dir angleStr station dist distStr
                   tableRow rowHeight insertionPoint tableObj angleThreshold bendCount blockName blockRefObj
                   blockInsertionPoint attributeObj attributesList rowCount colCount rowIndex colIndex cellValue
-                  roundedValue newValue quotient remainder deg min minStr angDegrees direction diff attValue
+                 roundedValue newValue quotient remainder deg myMin minStr angDegrees direction diff attValue
                   headingBlockName headingBlockRefObj headingAttributesList sel remainderStr frac)
 
   ;; -------------------------------------------------------------------------
@@ -20,29 +20,29 @@
        (* (- (nth 1 p2) (nth 1 p1)) (- (nth 0 p3) (nth 0 p1)))))
 
   ;; ----> UPDATED angToStr function with rounding <----
-  (defun angToStr (ang / deg frac min)
+  (defun angToStr (ang / deg frac myMin)
     ;; Separate the integer degrees from the fractional part
     (setq deg  (fix ang))
     (setq frac (- ang deg))
 
     ;; Convert fractional part to minutes
-    (setq min (* 60.0 frac))
+    (setq myMin (* 60.0 frac))
 
     ;; Round minutes
-    (setq min (fix (+ 0.5 min)))
+    (setq myMin (fix (+ 0.5 myMin)))
 
     ;; If rounding minutes hits 60, bump degrees
-    (if (>= min 60)
+    (if (>= myMin 60)
       (progn
         (setq deg (1+ deg))
-        (setq min (- min 60))
+        (setq myMin (- myMin 60))
       )
     )
 
     ;; Zero-pad single-digit minutes
-    (setq minStr (if (< min 10)
-                     (strcat "0" (itoa min))
-                     (itoa min)))
+    (setq minStr (if (< myMin 10)
+                     (strcat "0" (itoa myMin))
+                     (itoa myMin)))
 
     ;; Return something like 19%%D05'
     (strcat (itoa deg) "%%D" minStr "'")

--- a/AUTOCAD/LEGACY/LISP/COGO.LSP
+++ b/AUTOCAD/LEGACY/LISP/COGO.LSP
@@ -121,7 +121,6 @@
             (setq currentPt nextPt
                   prevAng   angIn))))
       )
-    )
     ;; restore vars
     (setvar "CMDECHO" oldCMDECHO)
     (setvar "DYNMODE"  oldDYNMODE))

--- a/AUTOCAD/LEGACY/LISP/bearing distance polyline.lsp
+++ b/AUTOCAD/LEGACY/LISP/bearing distance polyline.lsp
@@ -1,8 +1,8 @@
 (defun c:BPL (/ pl ent i pt1 pt2 lineAngle textAngle bearingAngle angleDegrees totalSeconds dist bearing
-                 textPos bearingPos distancePos degrees minutes seconds pi numSegments
+                 textPos bearingPos distancePos degrees minutes seconds myPi numSegments
                  originalClosedFlag layerName distanceTextResult bearingTextResult
                  textEntitiesToDelete positionOption dx dy offsetAngle flipped)
-  (setq pi (* 4 (atan 1.0))) ; Define pi
+  (setq myPi (* 4 (atan 1.0))) ; Define myPi
  
  ;; UTM check logic
   (if (l+getUTMstatus nil)
@@ -77,12 +77,12 @@
             (setq lineAngle (atan dy dx))
 
             ;; Calculate bearing angle from North, measured clockwise
-            (setq bearingAngle (- (/ pi 2) lineAngle))
+            (setq bearingAngle (- (/ myPi 2) lineAngle))
             (if (< bearingAngle 0)
-                (setq bearingAngle (+ bearingAngle (* 2 pi))))
+                (setq bearingAngle (+ bearingAngle (* 2 myPi))))
 
             ;; Convert bearingAngle to degrees/minutes/seconds
-            (setq angleDegrees (* bearingAngle (/ 180.0 pi)))
+            (setq angleDegrees (* bearingAngle (/ 180.0 myPi)))
             (setq totalSeconds (+ 0.5 (* angleDegrees 3600.0)))
             (setq degrees (fix (/ totalSeconds 3600.0)))
             (setq minutes (fix (/ (- totalSeconds (* degrees 3600.0)) 60.0)))
@@ -111,27 +111,27 @@
             (setq textAngle lineAngle)
             (setq flipped nil)
             (cond
-              ((> textAngle (/ pi 2)) 
-               (setq textAngle (- textAngle pi))
+              ((> textAngle (/ myPi 2)) 
+               (setq textAngle (- textAngle myPi))
                (setq flipped t)
               )
-              ((< textAngle (- (/ pi 2)))
-               (setq textAngle (+ textAngle pi))
+              ((< textAngle (- (/ myPi 2)))
+               (setq textAngle (+ textAngle myPi))
                (setq flipped t)
               )
             )
 
             ;; Determine offset angle based on Above/Below:
-            ;; Above = lineAngle + 90° (pi/2)
-            ;; Below = lineAngle - 90° (pi/2)
+            ;; Above = lineAngle + 90° (myPi/2)
+            ;; Below = lineAngle - 90° (myPi/2)
             (setq offsetAngle (if (equal positionOption "Above")
-                                  (+ lineAngle (/ pi 2))
-                                  (- lineAngle (/ pi 2))
+                                  (+ lineAngle (/ myPi 2))
+                                  (- lineAngle (/ myPi 2))
                                 ))
 
-            ;; If we flipped the text angle by pi, also flip the offset by pi to maintain correct side
+            ;; If we flipped the text angle by myPi, also flip the offset by myPi to maintain correct side
             (if flipped
-              (setq offsetAngle (+ offsetAngle pi))
+              (setq offsetAngle (+ offsetAngle myPi))
             )
 
             ;; Fixed distances

--- a/AUTOCAD/MODERN/LISP/Area Calc Simple.lsp
+++ b/AUTOCAD/MODERN/LISP/Area Calc Simple.lsp
@@ -3,9 +3,11 @@
 ;; No fancy predicates, works on any AutoCAD 2000-present
 ;; ======================================================================
 
+(defun sqm->ha (a) (/ a 10000.0))
+(defun sqm->ac (a) (/ a 4046.8564224))
+(defun round-str (v d) (rtos v 2 d))
+
 (defun c:AREACALC ( /
-        ;; helper fns
-        sqm->ha sqm->ac round-str
         ;; selections
         ssBoundary ssDispo ssCut ssWet
         ;; objects
@@ -24,9 +26,6 @@
   ;; basic helpers
   ;; ---------------------------------------------------------------
   (vl-load-com)
-  (defun sqm->ha (a) (/ a 10000.0))
-  (defun sqm->ac (a) (/ a 4046.8564224))
-  (defun round-str (v d) (rtos v 2 d))
 
   (prompt "\n=== Area Calculation Started ===")
 

--- a/AUTOCAD/MODERN/LISP/BendTable with bubbles.lsp
+++ b/AUTOCAD/MODERN/LISP/BendTable with bubbles.lsp
@@ -1,7 +1,7 @@
 (defun C:BT (/ plObj plPoints i ang nextAng prevAng lastPt thisPt nextPt dir angleStr station dist distStr
                   tableRow rowHeight insertionPoint tableObj angleThreshold bendCount blockName blockRefObj
                   blockInsertionPoint attributeObj attributesList rowCount colCount rowIndex colIndex cellValue
-                  roundedValue newValue quotient remainder deg min minStr angDegrees direction diff attValue
+                 roundedValue newValue quotient remainder deg myMin minStr angDegrees direction diff attValue
                   headingBlockName headingBlockRefObj headingAttributesList sel remainderStr frac)
 
   ;; -------------------------------------------------------------------------
@@ -20,29 +20,29 @@
        (* (- (nth 1 p2) (nth 1 p1)) (- (nth 0 p3) (nth 0 p1)))))
 
   ;; ----> UPDATED angToStr function with rounding <----
-  (defun angToStr (ang / deg frac min)
+  (defun angToStr (ang / deg frac myMin)
     ;; Separate the integer degrees from the fractional part
     (setq deg  (fix ang))
     (setq frac (- ang deg))
 
     ;; Convert fractional part to minutes
-    (setq min (* 60.0 frac))
+    (setq myMin (* 60.0 frac))
 
     ;; Round minutes
-    (setq min (fix (+ 0.5 min)))
+    (setq myMin (fix (+ 0.5 myMin)))
 
     ;; If rounding minutes hits 60, bump degrees
-    (if (>= min 60)
+    (if (>= myMin 60)
       (progn
         (setq deg (1+ deg))
-        (setq min (- min 60))
+        (setq myMin (- myMin 60))
       )
     )
 
     ;; Zero-pad single-digit minutes
-    (setq minStr (if (< min 10)
-                     (strcat "0" (itoa min))
-                     (itoa min)))
+    (setq minStr (if (< myMin 10)
+                     (strcat "0" (itoa myMin))
+                     (itoa myMin)))
 
     ;; Return something like 19%%D05'
     (strcat (itoa deg) "%%D" minStr "'")

--- a/AUTOCAD/MODERN/LISP/bearing distance polyline.lsp
+++ b/AUTOCAD/MODERN/LISP/bearing distance polyline.lsp
@@ -1,8 +1,8 @@
 (defun c:BPL (/ pl ent i pt1 pt2 lineAngle textAngle bearingAngle angleDegrees totalSeconds dist bearing
-                 textPos bearingPos distancePos degrees minutes seconds pi numSegments
+                 textPos bearingPos distancePos degrees minutes seconds myPi numSegments
                  originalClosedFlag layerName distanceTextResult bearingTextResult
                  textEntitiesToDelete positionOption dx dy offsetAngle flipped)
-  (setq pi (* 4 (atan 1.0))) ; Define pi
+  (setq myPi (* 4 (atan 1.0))) ; Define myPi
  
  ;; UTM check logic
   (if (l+getUTMstatus nil)
@@ -77,12 +77,12 @@
             (setq lineAngle (atan dy dx))
 
             ;; Calculate bearing angle from North, measured clockwise
-            (setq bearingAngle (- (/ pi 2) lineAngle))
+            (setq bearingAngle (- (/ myPi 2) lineAngle))
             (if (< bearingAngle 0)
-                (setq bearingAngle (+ bearingAngle (* 2 pi))))
+                (setq bearingAngle (+ bearingAngle (* 2 myPi))))
 
             ;; Convert bearingAngle to degrees/minutes/seconds
-            (setq angleDegrees (* bearingAngle (/ 180.0 pi)))
+            (setq angleDegrees (* bearingAngle (/ 180.0 myPi)))
             (setq totalSeconds (+ 0.5 (* angleDegrees 3600.0)))
             (setq degrees (fix (/ totalSeconds 3600.0)))
             (setq minutes (fix (/ (- totalSeconds (* degrees 3600.0)) 60.0)))
@@ -111,27 +111,27 @@
             (setq textAngle lineAngle)
             (setq flipped nil)
             (cond
-              ((> textAngle (/ pi 2)) 
-               (setq textAngle (- textAngle pi))
+              ((> textAngle (/ myPi 2)) 
+               (setq textAngle (- textAngle myPi))
                (setq flipped t)
               )
-              ((< textAngle (- (/ pi 2)))
-               (setq textAngle (+ textAngle pi))
+              ((< textAngle (- (/ myPi 2)))
+               (setq textAngle (+ textAngle myPi))
                (setq flipped t)
               )
             )
 
             ;; Determine offset angle based on Above/Below:
-            ;; Above = lineAngle + 90° (pi/2)
-            ;; Below = lineAngle - 90° (pi/2)
+            ;; Above = lineAngle + 90° (myPi/2)
+            ;; Below = lineAngle - 90° (myPi/2)
             (setq offsetAngle (if (equal positionOption "Above")
-                                  (+ lineAngle (/ pi 2))
-                                  (- lineAngle (/ pi 2))
+                                  (+ lineAngle (/ myPi 2))
+                                  (- lineAngle (/ myPi 2))
                                 ))
 
-            ;; If we flipped the text angle by pi, also flip the offset by pi to maintain correct side
+            ;; If we flipped the text angle by myPi, also flip the offset by myPi to maintain correct side
             (if flipped
-              (setq offsetAngle (+ offsetAngle pi))
+              (setq offsetAngle (+ offsetAngle myPi))
             )
 
             ;; Fixed distances


### PR DESCRIPTION
## Summary
- define helper functions at top level in *Area Calc Simple* routines
- rename local constant `pi` to `myPi` in *bearing distance polyline*
- rename temporary variable `min` to `myMin` in *BendTable with bubbles*
- fix unmatched parenthesis in *COGO* legacy version

## Testing
- `python3 - <<'EOF'
text=open('AUTOCAD/MODERN/LISP/COGO.LSP').read();
count=0
for c in text:
    if c=='(': count+=1
    elif c==')': count-=1
print('balanced' if count==0 else count)
EOF`
- `python3 - <<'EOF'
text=open('AUTOCAD/LEGACY/LISP/COGO.LSP').read();
count=0
for i,c in enumerate(text):
    if c=='(': count+=1
    elif c==')': count-=1
if count!=0:
    print('unbalanced',count)
else:
    print('balanced')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68826f4ec10c8322aaae2d7c872d2125