### PR TITLE
Fix UPCON duplicate selection

### DIFF
--- a/AUTOCAD/MODERN/LISP/UPCON.lsp
+++ b/AUTOCAD/MODERN/LISP/UPCON.lsp
@@ -12,7 +12,7 @@
 
 (defun c:UPCON ( / upcon-error upcon-old-error kw xyz dEnt dStr dPt
                    ssDesc pairL dupSel n pr chosen
-                   vtxL coord el i pt)
+                   vtxL coord el i pt entry)
 
   ;; Generic error handler
   (defun upcon-error (msg)
@@ -91,13 +91,18 @@
   (if (< (length pairL) 2)
       (progn (prompt "\nNeed at least two description/number pairs.") (exit)))
 
-  ;; STEP 4: remove duplicate point-numbers (keep first sorted)
-  (setq pairL  (vl-sort pairL '(lambda(a b) (< (car a) (car b))))
+  ;; STEP 4: remove duplicate point-numbers keeping the one
+  ;; nearest the originally selected description
+  (setq pairL  (vl-sort pairL '(lambda (a b) (< (car a) (car b))))
         chosen '())
   (foreach pr pairL
-    (if (not (assoc (car pr) chosen))
-      (setq chosen (cons pr chosen))))
-  (setq chosen (reverse chosen))
+    (setq entry (assoc (car pr) chosen))
+    (cond
+      ((null entry)
+       (setq chosen (cons pr chosen)))
+      ((> (distance dPt (cdr entry)) (distance dPt (cdr pr)))
+       (setq chosen (subst pr entry chosen)))))
+  (setq chosen (vl-sort chosen '(lambda (a b) (< (car a) (car b)))) )
   (if (< (length chosen) 2)
       (progn (prompt "\nFewer than two unique point-numbers.") (exit)))
 

--- a/LISP_CHANGES.md
+++ b/LISP_CHANGES.md
@@ -10,4 +10,5 @@
   - UTILS2025.lsp: `DTR`/`RTD` -> `utils-dtr`/`utils-rtd`.
   - PointConnect V2.lsp: `getcoord` -> `ax-pointconnect-getCoord`, added `pointconnect-error` handler and prefix UCS transform function.
   - GTECH.LSP and JTB UTM Tool.LSP: renamed UCS transform routines to `gtech-transW2C` and `utm-transW2C`.
+  - UPCON.lsp: duplicate point-numbers now resolved by choosing the description closest to the initial selection.
 


### PR DESCRIPTION
## Summary
- choose the description closest to the initial selection when multiple point numbers share the same value
- update change log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68827c9f095c83228998d7b04f4253df