### PR TITLE
Fix UPCON Z point matching

### DIFF
--- a/AUTOCAD/LEGACY/LISP/UPCON.lsp
+++ b/AUTOCAD/LEGACY/LISP/UPCON.lsp
@@ -28,13 +28,21 @@
   (setq kw  (getkword "\nInclude Z value? [Yes/No] <No>: ")
         xyz (if (or (null kw) (= kw "No")) nil T))
 
-  ;; Helper: get the true (x y z) for point-number string, or NIL
-  (defun ax-upcon-getCoord (ptext / sset ent coord)
+  ;; Helper: get the true (x y z) for point-number string near XY, or NIL
+  (defun ax-upcon-getCoord (ptext xy / sset ent coord)
     (setq sset
           (ssget "X"
                  (list (cons 0 "TEXT")
                        (cons 8 "Z-POINTNUMBER")
-                       (cons 1 ptext))))
+                       (cons 1 ptext)
+                       (cons -4 "=,=")
+                       (cons 10 xy))))
+    (if (or (null sset) (= (sslength sset) 0))
+      (setq sset
+            (ssget "X"
+                   (list (cons 0 "TEXT")
+                         (cons 8 "Z-POINTNUMBER")
+                         (cons 1 ptext)))))
     (if (and sset (> (sslength sset) 0))
       (progn
         (setq ent   (ssname sset 0)
@@ -102,18 +110,18 @@
       (progn (prompt "\nFewer than two unique point-numbers.") (exit)))
 
   ;; STEP 5: build vertex list with or without Z
-  (setq vtxL '())
-  (foreach pr chosen
-    (setq coord
-          (if xyz
-              (ax-upcon-getCoord (itoa (car pr)))
-              (progn
-                (setq pt (cdr pr))
-                (if (and pt (>= (length pt) 2))
-                    (list (car pt) (cadr pt) 0.0)
-                    (progn
-                      (princ (strcat "\nWarning: Invalid point data for number " (itoa (car pr))))
-                      nil)))))
+    (setq vtxL '())
+    (foreach pr chosen
+      (setq coord
+            (if xyz
+                (ax-upcon-getCoord (itoa (car pr)) (cdr pr))
+                (progn
+                  (setq pt (cdr pr))
+                  (if (and pt (>= (length pt) 2))
+                      (list (car pt) (cadr pt) 0.0)
+                      (progn
+                        (princ (strcat "\nWarning: Invalid point data for number " (itoa (car pr))))
+                        nil)))))
     (if coord
       (setq vtxL (cons (l+transw2c coord) vtxL))))
   (setq vtxL (reverse vtxL))

--- a/AUTOCAD/MODERN/LISP/UPCON.lsp
+++ b/AUTOCAD/MODERN/LISP/UPCON.lsp
@@ -28,13 +28,21 @@
   (setq kw  (getkword "\nInclude Z value? [Yes/No] <No>: ")
         xyz (if (or (null kw) (= kw "No")) nil T))
 
-  ;; Helper: get the true (x y z) for point-number string, or NIL
-  (defun ax-upcon-getCoord (ptext / sset ent coord)
+  ;; Helper: get the true (x y z) for point-number string near XY, or NIL
+  (defun ax-upcon-getCoord (ptext xy / sset ent coord)
     (setq sset
           (ssget "X"
                  (list (cons 0 "TEXT")
                        (cons 8 "Z-POINTNUMBER")
-                       (cons 1 ptext))))
+                       (cons 1 ptext)
+                       (cons -4 "=,=")
+                       (cons 10 xy))))
+    (if (or (null sset) (= (sslength sset) 0))
+      (setq sset
+            (ssget "X"
+                   (list (cons 0 "TEXT")
+                         (cons 8 "Z-POINTNUMBER")
+                         (cons 1 ptext)))))
     (if (and sset (> (sslength sset) 0))
       (progn
         (setq ent   (ssname sset 0)
@@ -112,8 +120,8 @@
     (setq coord nil
           pt (cdr pr))
     (cond
-      (xyz 
-       (setq coord (ax-upcon-getCoord (itoa (car pr)))))
+      (xyz
+       (setq coord (ax-upcon-getCoord (itoa (car pr)) pt)))
       ((and pt (> (length pt) 1))
        (setq coord (list (car pt) (car (cdr pt)) 0.0)))
       (t 

--- a/LISP_CHANGES.md
+++ b/LISP_CHANGES.md
@@ -11,4 +11,5 @@
   - PointConnect V2.lsp: `getcoord` -> `ax-pointconnect-getCoord`, added `pointconnect-error` handler and prefix UCS transform function.
   - GTECH.LSP and JTB UTM Tool.LSP: renamed UCS transform routines to `gtech-transW2C` and `utm-transW2C`.
   - UPCON.lsp: duplicate point-numbers now resolved by choosing the description closest to the initial selection.
+  - UPCON.lsp: when including Z values, point-number lookup now filters by the description's XY to avoid mismatched points.
 


### PR DESCRIPTION
## Summary
- make UPCON use the description's XY when looking up point numbers
- update duplicate handling when Z values are included
- document fix in change log

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68828747739c8322a38799b546472021