### PR TITLE
Implement SECTRIM AutoLISP command

### DIFF
--- a/AUTOCAD/MODERN/LISP/SECTRIM.LSP
+++ b/AUTOCAD/MODERN/LISP/SECTRIM.LSP
@@ -1,2 +1,33 @@
-;; PLACE HOLDER
+(vl-load-com)
 
+(defun c:SECTRIM ( / ent data ins xScale rad cir moveVec ss )
+  (setvar "cmdecho" 0)
+  (prompt "\nSelect block to trim around: ")
+  (if (and (setq ent (car (entsel)))
+           (setq data (entget ent))
+           (= (cdr (assoc 0 data)) "INSERT"))
+    (progn
+      (setq ins    (cdr (assoc 10 data))
+            xScale (cond ((cdr (assoc 41 data))) (1.0))
+            rad    (* 40 xScale)
+      )
+      ;; Draw circle at insertion point
+      (command "_.CIRCLE" ins rad)
+      (setq cir (entlast))
+      ;; Move circle down (negative Y) 10 units * X scale
+      (setq moveVec (list 0.0 (* -10 xScale) 0.0))
+      (command "_.MOVE" cir "" '(0 0 0) moveVec)
+      ;; Trim all geometry crossing inside the circle
+      (setq ss (ssget "_X"))
+      (setq ss (ssdel cir ss))
+      (if ss
+        (vl-cmdf "_.TRIM" cir "" ss "")
+      )
+    )
+    (prompt "\nBlock selection required.")
+  )
+  (setvar "cmdecho" 1)
+  (princ)
+)
+
+(princ)


### PR DESCRIPTION
## Summary
- add actual implementation for `SECTRIM.LSP`
  - select a block reference
  - use block X scale to size a circle
  - move the circle down by the scale factor
  - trim geometry inside the circle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ccabc7a08322b81edc9c4baa9c1b